### PR TITLE
Hotfix 8

### DIFF
--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ExtendedScrollViewer.xaml.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ExtendedScrollViewer.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 namespace Diagrammatist.Presentation.WPF.Core.Controls
 {
@@ -190,6 +191,7 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
         // Flags to avoid feedback loops
         private bool _settingOffsetFromDP;
         private bool _settingDPFromScroll;
+        private bool _isRestoring;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExtendedScrollViewer"/> class.
@@ -218,7 +220,26 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
         public void ZoomReset()
         {
             Zoom = 1f;
-            Dispatcher.BeginInvoke(CenterContent, System.Windows.Threading.DispatcherPriority.Render);
+            Dispatcher.BeginInvoke(CenterContent, DispatcherPriority.Render);
+        }
+
+        /// <summary>
+        /// Restores the state of the scroll viewer with the specified zoom level and offsets.
+        /// </summary>
+        /// <param name="zoom"></param>
+        /// <param name="hOffset"></param>
+        /// <param name="vOffset"></param>
+        public void RestoreState(float zoom, double hOffset, double vOffset)
+        {
+            _isRestoring = true;
+
+            Zoom = zoom;
+
+            Dispatcher.BeginInvoke(() =>
+            {
+                HorizontalOffset = hOffset;
+                VerticalOffset = vOffset;
+            }, DispatcherPriority.Render);
         }
 
         private void OnScrollViewerLoaded(object sender, RoutedEventArgs e)
@@ -321,6 +342,8 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
 
         private void OnScrollChanged(object sender, ScrollChangedEventArgs e)
         {
+            if (_isRestoring) return;
+
             if (e.ExtentWidthChange == 0 && e.ExtentHeightChange == 0) return;
 
             Point? before = null, now = null;

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ObservablePolyline.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ObservablePolyline.cs
@@ -96,7 +96,7 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
             StrokeThicknessProperty.OverrideMetadata(
                 typeof(ObservablePolyline),
                 new FrameworkPropertyMetadata(
-                    1.0,
+                    2.0,
                     FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure,
                     OnAppearanceChanged));
         }
@@ -144,7 +144,7 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
                     var dir = to - from; 
                     dir.Normalize();
                     var perp = new Vector(-dir.Y, dir.X);
-                    var size = StrokeThickness * 2;
+                    var size = StrokeThickness * 5;
 
                     var tip = to;
                     var b1 = to - dir * size + perp * (size / 2);

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ObservablePolyline.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Controls/ObservablePolyline.cs
@@ -89,10 +89,22 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
         }
 
         /// <summary>
-        /// Gets defining geometry.
+        /// Static constructor to override metadata for StrokeThickness property.
         /// </summary>
+        static ObservablePolyline()
+        {
+            StrokeThicknessProperty.OverrideMetadata(
+                typeof(ObservablePolyline),
+                new FrameworkPropertyMetadata(
+                    1.0,
+                    FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure,
+                    OnAppearanceChanged));
+        }
+
+        /// <inheritdoc/>
         protected override Geometry DefiningGeometry => _polylineGeometry;
 
+        /// <inheritdoc/>
         protected override Size MeasureOverride(Size constraint)
         {
             if (Points == null || Points.Count == 0)
@@ -103,51 +115,49 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
         }
 
         /// <summary>
-        /// Updates polyline.
+        /// Updates the polyline geometry based on the current points.
         /// </summary>
         protected void UpdatePolyline()
         {
             if (Points == null || Points.Count < 2)
             {
-                _polylineGeometry = Geometry.Empty;
-                PosX = 0;
-                PosY = 0;
+                return;
             }
-            else
+
+            var minX = Points.Min(p => p.X);
+            var minY = Points.Min(p => p.Y);
+            PosX = minX;
+            PosY = minY;
+
+            var pts = Points.Select(p => new Point(p.X - minX, p.Y - minY)).ToList();
+
+            var geometry = new StreamGeometry { FillRule = FillRule };
+            using (var ctx = geometry.Open())
             {
-                double minX = Points.Min(p => p.X);
-                double minY = Points.Min(p => p.Y);
+                ctx.BeginFigure(pts[0], isFilled: false, isClosed: false);
+                ctx.PolyLineTo(pts.Skip(1).ToList(), isStroked: true, isSmoothJoin: true);
 
-                PosX = minX;
-                PosY = minY;
-
-                var relativePoints = Points
-                    .Select(p => new Point(p.X - minX, p.Y - minY))
-                    .ToList();
-
-                var geometry = new PathGeometry { FillRule = FillRule };
-                for (int i = 1; i < relativePoints.Count; i++)
+                if (HasArrow)
                 {
-                    var figure = new PathFigure
-                    {
-                        StartPoint = relativePoints[i - 1],
-                        IsClosed = false
-                    };
-                    figure.Segments.Add(new LineSegment(relativePoints[i], true));
-                    geometry.Figures.Add(figure);
+                    var from = pts[^2];
+                    var to = pts[^1];
+                    var dir = to - from; 
+                    dir.Normalize();
+                    var perp = new Vector(-dir.Y, dir.X);
+                    var size = StrokeThickness * 2;
+
+                    var tip = to;
+                    var b1 = to - dir * size + perp * (size / 2);
+                    var b2 = to - dir * size - perp * (size / 2);
+
+                    ctx.BeginFigure(tip, isFilled: true, isClosed: true);
+                    ctx.LineTo(b1, isStroked: true, isSmoothJoin: false);
+                    ctx.LineTo(b2, isStroked: true, isSmoothJoin: false);
                 }
-
-                if (HasArrow && relativePoints.Count >= 2)
-                {
-                    Point from = relativePoints[^2];
-                    Point to = relativePoints[^1];
-
-                    var arrowFigure = CreateArrowHead(from, to);
-                    geometry.Figures.Add(arrowFigure);
-                }
-
-                _polylineGeometry = geometry;
             }
+
+            geometry.Freeze();
+            _polylineGeometry = geometry;
 
             InvalidateVisual();
         }
@@ -157,10 +167,10 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
             if (Points == null || Points.Count == 0)
                 return Rect.Empty;
 
-            double minX = Points.Min(p => p.X);
-            double minY = Points.Min(p => p.Y);
-            double maxX = Points.Max(p => p.X);
-            double maxY = Points.Max(p => p.Y);
+            var minX = Points.Min(p => p.X);
+            var minY = Points.Min(p => p.Y);
+            var maxX = Points.Max(p => p.X);
+            var maxY = Points.Max(p => p.Y);
 
             return new Rect(new Point(minX, minY), new Point(maxX, maxY));
         }
@@ -182,33 +192,16 @@ namespace Diagrammatist.Presentation.WPF.Core.Controls
             InvalidateMeasure();
         }
 
-        private PathFigure CreateArrowHead(Point from, Point to, double size = 10)
-        {
-            var direction = to - from;
-            direction.Normalize();
-
-            var perpendicular = new Vector(-direction.Y, direction.X);
-
-            var arrowTip = to;
-            var base1 = to - direction * size + perpendicular * (size / 2);
-            var base2 = to - direction * size - perpendicular * (size / 2);
-
-            return new PathFigure
-            {
-                StartPoint = base1,
-                Segments =
-                [
-                    new LineSegment(base2, true),
-                    new LineSegment(arrowTip, true)
-                ],
-                IsClosed = true,
-                IsFilled = true
-            };
-        }
-
         private static void OnHasArrowChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             ((ObservablePolyline)d).UpdatePolyline();
+        }
+
+        private static void OnAppearanceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var poly = (ObservablePolyline)d;
+            poly.UpdatePolyline();
+            poly.InvalidateMeasure();
         }
     }
 }

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Helpers/FigureNameHelper.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Helpers/FigureNameHelper.cs
@@ -1,0 +1,70 @@
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Diagrammatist.Presentation.WPF.Core.Helpers
+{
+    /// <summary>
+    /// A static class that provides helper methods for figure names.
+    /// </summary>
+    public static partial class FigureNameHelper
+    {
+        /// <summary>
+        /// Generates a unique name based on the provided base name and a collection of existing names.
+        /// </summary>
+        /// <param name="baseName"></param>
+        /// <param name="existingNames"></param>
+        /// <returns></returns>
+        public static string GetUniqueName(string baseName, IEnumerable<string>? existingNames)
+        {
+            if (existingNames == null)
+                return baseName;
+
+            var namesSet = existingNames.ToHashSet();
+            if (!namesSet.Contains(baseName))
+                return baseName;
+
+            var match = SuffixRegex().Match(baseName);
+            string coreName;
+            int startIndex;
+
+            if (match.Success && int.TryParse(match.Groups[2].Value, out var parsed))
+            {
+                coreName = match.Groups[1].Value;
+                startIndex = parsed + 1;
+            }
+            else
+            {
+                coreName = baseName;
+                startIndex = 1;
+            }
+
+            string candidate;
+            int index = startIndex;
+
+            do
+            {
+                candidate = $"{coreName} {index}";
+                index++;
+            } while (namesSet.Contains(candidate));
+
+            return candidate;
+        }
+
+        /// <summary>
+        /// Retrieves the translated name for a given key from the localization resources.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public static string GetTranslatedName(string key)
+        {
+            var resourcesAssembly = Assembly.GetCallingAssembly().GetName().Name;
+            return LocalizationHelper.GetLocalizedValue<string>(
+                resourcesAssembly ?? string.Empty,
+                "Figures.FiguresResources",
+                key);
+        }
+
+        [GeneratedRegex(@"^(.*) (\d+)$", RegexOptions.Compiled)]
+        private static partial Regex SuffixRegex();
+    }
+}

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Helpers/LocalizationHelper.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Helpers/LocalizationHelper.cs
@@ -19,5 +19,18 @@ namespace Diagrammatist.Presentation.WPF.Core.Helpers
         {
             return LocExtension.GetLocalizedValue<T>($"{Assembly.GetCallingAssembly().GetName().Name}:Resources.Localization.{resource}:{key}");
         }
+
+        /// <summary>
+        /// Gets localized value from dictionary using assembly name, resource and key.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="assemblyName"></param>
+        /// <param name="resource"></param>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public static T GetLocalizedValue<T>(string assemblyName, string resource, string key)
+        {
+            return LocExtension.GetLocalizedValue<T>($"{assemblyName}:Resources.Localization.{resource}:{key}");
+        }
     }
 }

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Managers/Tabs/DocumentTabsManager.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Managers/Tabs/DocumentTabsManager.cs
@@ -1,5 +1,6 @@
 ﻿using Diagrammatist.Presentation.WPF.Core.Models.Canvas;
 using Diagrammatist.Presentation.WPF.Core.Models.Document;
+using Diagrammatist.Presentation.WPF.Core.Services.Figure.Placement;
 using System.Collections.ObjectModel;
 
 namespace Diagrammatist.Presentation.WPF.Core.Managers.Tabs
@@ -12,6 +13,17 @@ namespace Diagrammatist.Presentation.WPF.Core.Managers.Tabs
         private readonly ObservableCollection<CanvasModel> _canvases = [];
         private readonly Dictionary<CanvasModel, string> _filePaths = [];
         private readonly Collection<DocumentModel> _documents = [];
+
+        private readonly IFigurePlacementService _figurePlacementService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentTabsManager"/> class.
+        /// </summary>
+        /// <param name="figurePlacementService"></param>
+        public DocumentTabsManager(IFigurePlacementService figurePlacementService)
+        {
+            _figurePlacementService = figurePlacementService;
+        }
 
         /// <inheritdoc/>
         public ObservableCollection<CanvasModel> Canvases => _canvases;
@@ -28,6 +40,8 @@ namespace Diagrammatist.Presentation.WPF.Core.Managers.Tabs
             if (!_canvases.Contains(document.Canvas) && document.Canvas is { } canvas)
             {
                 _canvases.Add(canvas);
+                TrackChanges(canvas);
+
                 _filePaths[canvas] = filePath;
                 _documents.Add(document);
             }
@@ -62,6 +76,14 @@ namespace Diagrammatist.Presentation.WPF.Core.Managers.Tabs
             if (_canvases.Contains(canvas))
             {
                 _filePaths[canvas] = filePath;
+            }
+        }
+
+        private void TrackChanges(CanvasModel canvas)
+        {
+            foreach (var figure in canvas.Figures)
+            {
+                _figurePlacementService.TrackChanges(figure);
             }
         }
     }

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Messaging/Messages/RestoreCanvasStateMessage.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Messaging/Messages/RestoreCanvasStateMessage.cs
@@ -1,0 +1,15 @@
+﻿using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace Diagrammatist.Presentation.WPF.Core.Messaging.Messages
+{
+    /// <summary>
+    /// A message that is used to restore the canvas state, including zoom level and offsets.
+    /// </summary>
+    public class RestoreCanvasStateMessage : ValueChangedMessage<(float zoom, double hOffset, double vOffset)>
+    {
+        /// <inheritdoc/>
+        public RestoreCanvasStateMessage((float zoom, double hOffset, double vOffset) value) : base(value)
+        {
+        }
+    }
+}

--- a/src/Presentation/Diagrammatist.Presentation.WPF.Core/Services/Figure/Manipulation/FigureManipulationService.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF.Core/Services/Figure/Manipulation/FigureManipulationService.cs
@@ -48,6 +48,7 @@ namespace Diagrammatist.Presentation.WPF.Core.Services.Figure.Manipulation
         public void Duplicate(FigureModel figure, ICollection<FigureModel> figures)
         {
             var clone = figure.Clone();
+            GetUniqueName(clone, figures);
 
             var command = CommonUndoableHelper.CreateUndoableCommand(
                 () => figures.Add(clone),
@@ -62,6 +63,8 @@ namespace Diagrammatist.Presentation.WPF.Core.Services.Figure.Manipulation
             if (_clipboardService.GetFromClipboard()?.Clone() is not { } pastedFigure)
                 return;
 
+            GetUniqueName(pastedFigure, figures);
+
             var command = CommonUndoableHelper.CreateUndoableCommand(
                 () => figures.Add(pastedFigure),
                 () => figures.Remove(pastedFigure));
@@ -74,6 +77,8 @@ namespace Diagrammatist.Presentation.WPF.Core.Services.Figure.Manipulation
         {
             if (_clipboardService.GetFromClipboard()?.Clone() is not { } pastedFigure || pos is not Point point)
                 return;
+
+            GetUniqueName(pastedFigure, figures);
 
             var command = CommonUndoableHelper.CreateUndoableCommand(
                 () =>
@@ -167,6 +172,11 @@ namespace Diagrammatist.Presentation.WPF.Core.Services.Figure.Manipulation
                 });
 
             _commandManager.Execute(command);
+        }
+
+        private void GetUniqueName(FigureModel figure, ICollection<FigureModel> figures)
+        {
+            figure.Name = FigureNameHelper.GetUniqueName(figure.Name, figures.Select(f => f.Name));
         }
     }
 }

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Diagrammatist.Presentation.WPF.csproj
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Diagrammatist.Presentation.WPF.csproj
@@ -12,7 +12,13 @@
 
   <PropertyGroup>
 	<AssemblyTitle>Diagrammatist</AssemblyTitle>
-	<Version>1.0.0-rc3</Version>
+	<AssemblyVersion>1.0.0.0</AssemblyVersion>
+	<FileVersion>1.0.0.0</FileVersion>
+	<InformationalVersion>1.0.0-rc3</InformationalVersion>
+	<Company>Made by Alexei 'fral' Rodionov</Company>
+	<Authors>Alexei 'fral' Rodionov</Authors>
+	<Product>Diagrammatist</Product>
+	<Copyright>© 2025 Alexei "fral" Rodionov</Copyright>
   </PropertyGroup>
 	
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Resources/Styles/Bindings.xaml
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Resources/Styles/Bindings.xaml
@@ -38,6 +38,10 @@
         <Setter Property="Canvas.Left" Value="{Binding PosX, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         <Setter Property="Canvas.Top" Value="{Binding PosY, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         <Setter Property="Canvas.ZIndex" Value="{Binding ZIndex}"/>
+        <Setter Property="IsHitTestVisible" Value="{Binding Path=DataContext.CurrentMouseMode, 
+                                                            RelativeSource={RelativeSource AncestorType=ListBox},
+                                                            Converter={StaticResource EnumToBooleanConverter}, 
+                                                            ConverterParameter='Select'}" />
         <Setter Property="RenderTransformOrigin" Value="0.5, 0.5"/>
         <Setter Property="RenderTransform">
             <Setter.Value>

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Resources/Styles/Styles.xaml
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Resources/Styles/Styles.xaml
@@ -1095,16 +1095,18 @@
         <Setter Property="Padding" Value="4"/>
         <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ComboBox">
-                    <Grid>
+                    <Grid FocusVisualStyle="{x:Null}">
                         <Border x:Name="Border"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="4"
-                                Padding="4">
+                                Padding="4"
+                                FocusVisualStyle="{x:Null}">
                             <Grid>
                                 <ContentPresenter x:Name="ContentSite"
                                                   Content="{TemplateBinding SelectionBoxItem}"
@@ -1118,7 +1120,7 @@
                                       StrokeThickness="2"
                                       HorizontalAlignment="Right"
                                       VerticalAlignment="Center"
-                                      Margin="8,0"/>
+                                      Margin="8 0"/>
                                 <ToggleButton x:Name="MainToggleButton"
                                               Background="Transparent"
                                               BorderThickness="0"

--- a/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/CanvasViewModel.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/CanvasViewModel.cs
@@ -75,6 +75,13 @@ namespace Diagrammatist.Presentation.WPF.ViewModels.Components
         /// This event is triggered when user adds a figure from canvas non-visible area.
         /// </remarks>
         public event Action<FigureModel>? RequestScrollToFigure;
+        /// <summary>
+        /// Occurs when a request is made to restore canvas state (zoom and offsets).
+        /// </summary>
+        /// <remarks> 
+        /// This event is triggered when user initiates a restore action from menu button.
+        /// </remarks>
+        public event Action<(float zoom, double hOffset, double vOffset)> RequestRestoreState;
 
         private CanvasModel? _currentCanvas;
 
@@ -544,6 +551,14 @@ namespace Diagrammatist.Presentation.WPF.ViewModels.Components
             Messenger.Register<CanvasViewModel, ExportSettingsMessage>(this, (r, m) =>
             {
                 Export(m.Value);
+            });
+            // Restore canvas state.
+            Messenger.Register<CanvasViewModel, RestoreCanvasStateMessage>(this, (r, m) =>
+            {
+                if (m.Value is { } value)
+                {
+                    RequestRestoreState?.Invoke(value);
+                }
             });
             // Answer to current canvas request.
             Messenger.Register<CanvasViewModel, CurrentCanvasRequestMessage>(this, (r, m) =>

--- a/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/FiguresViewModel.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/FiguresViewModel.cs
@@ -185,37 +185,14 @@ namespace Diagrammatist.Presentation.WPF.ViewModels.Components
             }
         }
 
-        private string GetUniqueFigureName(string baseName)
-        {
-            if (CanvasFigures is null)
-                return baseName;
-
-            var existingNames = CanvasFigures.Select(f => f.Name).ToHashSet();
-            if (!existingNames.Contains(baseName))
-                return baseName;
-
-            var index = 1;
-            var newName = string.Empty;
-            
-            do
-            {
-                newName = $"{baseName} {index}";
-                index++;
-            } while (existingNames.Contains(newName));
-
-            return newName;
-        }
-
-        private string GetTranslatedFigureName(string baseName)
-        {
-            return LocalizationHelper.GetLocalizedValue<string>("Figures.FiguresResources", baseName);
-        }
-
         private T CloneAndRename<T>(T template) where T : FigureModel
         {
             var clone = (T)template.Clone();
-            var translatedName = GetTranslatedFigureName(clone.Name);
-            clone.Name = GetUniqueFigureName(translatedName);
+            var translatedName = FigureNameHelper.GetTranslatedName(clone.Name);
+
+            var existingNames = CanvasFigures?.Select(f => f.Name);
+            clone.Name = FigureNameHelper.GetUniqueName(translatedName, existingNames?.ToList());
+
             return clone;
         }
 
@@ -273,7 +250,8 @@ namespace Diagrammatist.Presentation.WPF.ViewModels.Components
                     CanvasConnections!
                 );
 
-            figure.Name = GetUniqueFigureName(GetTranslatedFigureName(figure.Name));
+            var existingNames = CanvasFigures?.Select(f => f.Name);
+            figure.Name = FigureNameHelper.GetUniqueName(FigureNameHelper.GetTranslatedName(figure.Name), existingNames);
             figure.Points = points.ToObservableCollection();
 
             AddConnectionIfNeeded(start, end, figure);

--- a/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/TabsViewModel.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/ViewModels/Components/TabsViewModel.cs
@@ -199,6 +199,22 @@ namespace Diagrammatist.Presentation.WPF.ViewModels.Components
             RemoveDocument(doc);
         }
 
+        /// <summary>
+        /// Occurs when tab is changed.
+        /// </summary>
+        [RelayCommand]
+        private void TabChanged()
+        {
+            if (SelectedCanvas is null)
+                return;
+
+            Messenger.Send(new RestoreCanvasStateMessage((
+                Convert.ToSingle(SelectedCanvas.Zoom),
+                SelectedCanvas.Offset.X,
+                SelectedCanvas.Offset.Y
+            )));
+        }
+
         private void CloseDocuments()
         {
             foreach (var canvas in Canvases.ToList())

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml
@@ -37,8 +37,8 @@
                     CommandParameter="{Binding SelectedFigure}"/>
     </UserControl.InputBindings>
 
-    <controls:ExtendedScrollViewer VerticalOffset="{Binding CurrentCanvas.Offset.X, Mode=TwoWay, FallbackValue=0}"
-                                   HorizontalOffset="{Binding CurrentCanvas.Offset.Y, Mode=TwoWay, FallbackValue=0}"
+    <controls:ExtendedScrollViewer VerticalOffset="{Binding CurrentCanvas.Offset.Y, Mode=TwoWay, FallbackValue=0}"
+                                   HorizontalOffset="{Binding CurrentCanvas.Offset.X, Mode=TwoWay, FallbackValue=0}"
                                    Focusable="False"
                                    IsPanEnabled="{Binding CurrentMouseMode, Converter={StaticResource MouseModeIsControlConverter}, ConverterParameter='Pan'}"
                                    Cursor="{Binding CurrentMouseMode, Converter={StaticResource MouseModeToCursorConverter}}"

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml
@@ -52,7 +52,8 @@
                      SelectedItem="{Binding SelectedFigure}"
                      Template="{StaticResource UnscrollableListBox}"
                      PreviewMouseLeftButtonDown="OnListBoxPreviewMouseLeftButtonDown"
-                     Loaded="OnListBoxLoaded">
+                     Loaded="OnListBoxLoaded"
+                     IsTabStop="False">
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
                         <controls:ExtendedCanvas Width="{Binding DataContext.CurrentCanvas.Settings.Width, RelativeSource={RelativeSource AncestorType=ListBox}, FallbackValue=0}"

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/CanvasComponent.xaml.cs
@@ -12,7 +12,6 @@ using Microsoft.Win32;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Threading;
 
 namespace Diagrammatist.Presentation.WPF.Views.Components
@@ -51,6 +50,11 @@ namespace Diagrammatist.Presentation.WPF.Views.Components
             viewModel.RequestExport += Export;
             viewModel.RequestVisibleArea += GetVisibleArea;
             viewModel.RequestScrollToFigure += ScrollToFigure;
+            
+            viewModel.RequestRestoreState += (args) =>
+            {
+                extScrollViewer.RestoreState(args.zoom, args.hOffset, args.vOffset);
+            };
         }
 
         #region Event handlers

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/TabsComponent.xaml
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/TabsComponent.xaml
@@ -1,7 +1,8 @@
 ﻿<UserControl x:Class="Diagrammatist.Presentation.WPF.Views.Components.TabsComponent"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Diagrammatist.Presentation.WPF.Views.Components" 
              xmlns:viewmodels="clr-namespace:Diagrammatist.Presentation.WPF.ViewModels.Components"
@@ -53,5 +54,11 @@
                 <StackPanel Orientation="Horizontal"/>
             </ItemsPanelTemplate>
         </ListBox.ItemsPanel>
+        <i:Interaction.Triggers>
+            <i:EventTrigger EventName="SelectionChanged">
+                <i:InvokeCommandAction Command="{Binding DataContext.TabChangedCommand, RelativeSource={RelativeSource AncestorType=ListBox}}" 
+                                       PassEventArgsToCommand="False"/>
+            </i:EventTrigger>
+        </i:Interaction.Triggers>
     </ListBox>
 </UserControl>

--- a/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/TabsComponent.xaml.cs
+++ b/src/Presentation/Diagrammatist.Presentation.WPF/Views/Components/TabsComponent.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Diagrammatist.Presentation.WPF.Core.Foundation.Extensions;
+﻿using Diagrammatist.Presentation.WPF.Core.Controls;
+using Diagrammatist.Presentation.WPF.Core.Foundation.Extensions;
 using Diagrammatist.Presentation.WPF.Core.Helpers;
 using Diagrammatist.Presentation.WPF.Core.Models.Canvas;
 using Diagrammatist.Presentation.WPF.Core.Services.Alert;
@@ -147,7 +148,6 @@ namespace Diagrammatist.Presentation.WPF.Views.Components
                 }
             }
         }
-
         #endregion
     }
 }


### PR DESCRIPTION
- Arrow Drawing: Item selection is now disabled when drawing arrows.
- Canvas Scaling: Canvas scaling level is correctly restored when the canvas is reopened.
- Arrowheads: Arrowheads are now displayed in full (no visual clipping).
- Dynamic Guides: Fixed objects (such as arrows) are no longer considered when aligning dynamic guides.
- Canvas border behavior: Arrows are no longer pulled out uncontrollably when dragging blocks beyond canvas borders.
- Duplicate and Paste: Unique names are now preserved when duplicating and pasting elements.
- Published files: Organization and version metadata are correctly updated when published.
- Alt highlight effect: Eliminated unwanted highlight effect when using the Alt key (especially noticeable on the canvas).